### PR TITLE
Single sustain per unit per combat round

### DIFF
--- a/component/helpView.tsx
+++ b/component/helpView.tsx
@@ -73,10 +73,6 @@ export default function HelpView({ style }: Props) {
               <li>Relic &quot;The Crown of Thalnos&quot; is missing</li>
               <li>L1z1x mech can&apos;t be used to bombard during a ground invasion.</li>
               <li>
-                Empyrean flagship can repair the same unit several times during the same combat
-                round. This is not supposed to happen.
-              </li>
-              <li>
                 If a carrier is killed by a PDS then fighters without capacity should die. Currently
                 capacity is ignored.
               </li>

--- a/component/helpView.tsx
+++ b/component/helpView.tsx
@@ -77,11 +77,12 @@ export default function HelpView({ style }: Props) {
                 capacity is ignored.
               </li>
               <li>
-                If the mentak hero kills a war sun, Mentak must have the war sun technology to steal
+                If the Mentak hero kills a war sun, Mentak must have the war sun technology to steal
                 it. In the simulation we always steal it.
               </li>
               <li>
-                Baronys &quot;War Funding&quot; only rerolls their own dice, never their opponents
+                Barony&apos;s &quot;War Funding&quot; only rerolls their own dice, never their
+                opponents
               </li>
             </ul>
           </div>

--- a/core/battle.ts
+++ b/core/battle.ts
@@ -91,6 +91,9 @@ export function doBattle(battle: BattleInstance): BattleResult {
       }
     }
 
+    clearSustains(battle.attacker)
+    clearSustains(battle.defender)
+
     addNewUnits(battle.attacker)
     addNewUnits(battle.defender)
 
@@ -127,6 +130,10 @@ export function doBattle(battle: BattleInstance): BattleResult {
   }
 
   return battleResult
+}
+
+function clearSustains(p: ParticipantInstance) {
+  p.units.forEach((u) => (u.usedSustain = false))
 }
 
 function addNewUnits(p: ParticipantInstance) {
@@ -519,7 +526,12 @@ function applyHit(
   } else {
     const bestDieUnit = getLowestWorthUnit(p, battle.place, includeFighter)
     if (bestDieUnit) {
-      if (!sustainDisabled && bestDieUnit.sustainDamage && !bestDieUnit.takenDamage) {
+      if (
+        !sustainDisabled &&
+        bestDieUnit.sustainDamage &&
+        !bestDieUnit.takenDamage &&
+        !bestDieUnit.usedSustain
+      ) {
         doSustainDamage(battle, p, bestDieUnit, isDuringCombat)
       } else {
         bestDieUnit.isDestroyed = true
@@ -541,6 +553,7 @@ function doSustainDamage(
 ) {
   unit.takenDamage = true
   unit.takenDamageRound = battle.roundNumber
+  unit.usedSustain = true
   p.onSustainEffect.forEach((effect) => {
     if (canBattleEffectBeUsed(effect, p)) {
       effect.onSustain!(unit, p, battle, effect.name, isDuringCombat)

--- a/core/battle.ts
+++ b/core/battle.ts
@@ -91,9 +91,6 @@ export function doBattle(battle: BattleInstance): BattleResult {
       }
     }
 
-    clearSustains(battle.attacker)
-    clearSustains(battle.defender)
-
     addNewUnits(battle.attacker)
     addNewUnits(battle.defender)
 
@@ -401,6 +398,8 @@ function resolveHits(battle: BattleInstance, isDuringCombat: boolean) {
     removeDeadUnits(battle.attacker, battle)
     removeDeadUnits(battle.defender, battle)
   }
+  clearSustains(battle.attacker)
+  clearSustains(battle.defender)
 }
 
 function hasHitToAssign(p: ParticipantInstance) {

--- a/core/battleeffect/actioncard.ts
+++ b/core/battleeffect/actioncard.ts
@@ -25,7 +25,7 @@ export function getActioncards() {
     experimentalBattlestation,
     fighterPrototype,
     fireTeam,
-    maneuveringJets,
+    // maneuveringJets,
     moraleBoost,
     shieldsHolding,
     blitz,

--- a/core/factions/baronyOfLetnev.ts
+++ b/core/factions/baronyOfLetnev.ts
@@ -76,6 +76,7 @@ export const baronyOfLetnev: BattleEffect[] = [
           participant.units[infantryIndex] = {
             ...genericMech,
             takenDamage: false,
+            usedSustain: false,
             isDestroyed: false,
             combat: {
               ...infantry.combat!,

--- a/core/factions/empyrean.test.ts
+++ b/core/factions/empyrean.test.ts
@@ -1,0 +1,135 @@
+import getBattleReport from '..'
+import { checkResult, getTestParticipant } from '../../util/util.test'
+import { Faction, Place } from '../enums'
+import { DO_BATTLE_X_TIMES } from '../index.test'
+
+const ENDLESS_REPAIR = 1000
+
+describe('Empyrean', () => {
+  it('Empyrean flagship with endless repairs should win a 1v1 vs a dread', () => {
+    const attacker = getTestParticipant(
+      'attacker',
+      {
+        flagship: 1,
+      },
+      Faction.empyrean,
+      {
+        'Empyrean flagship repair': ENDLESS_REPAIR,
+      },
+    )
+
+    const defender = getTestParticipant(
+      'defender',
+      {
+        dreadnought: 1,
+      },
+      Faction.muaat,
+    )
+
+    const result = getBattleReport(attacker, defender, Place.space, DO_BATTLE_X_TIMES)
+
+    checkResult(result.attacker, DO_BATTLE_X_TIMES)
+    checkResult(result.draw, 0)
+    checkResult(result.defender, 0)
+  })
+
+  it('Empyrean flagship and dread risking direct hit with endless repairs should always beat 2 dread', () => {
+    const attacker = getTestParticipant(
+      'attacker',
+      {
+        flagship: 1,
+      },
+      Faction.empyrean,
+      {
+        'Empyrean flagship repair': ENDLESS_REPAIR,
+      },
+    )
+    attacker.riskDirectHit = true
+
+    const defender = getTestParticipant(
+      'defender',
+      {
+        dreadnought: 1,
+      },
+      Faction.muaat,
+    )
+
+    const result = getBattleReport(attacker, defender, Place.space, DO_BATTLE_X_TIMES)
+
+    checkResult(result.attacker, DO_BATTLE_X_TIMES)
+    checkResult(result.draw, 0)
+    checkResult(result.defender, 0)
+  })
+
+  it('Empyrean flagship with endless repairs should lose more times than it wins vs 1 dread with direct hit', () => {
+    const attacker = getTestParticipant(
+      'attacker',
+      {
+        flagship: 1,
+      },
+      Faction.empyrean,
+      {
+        'Empyrean flagship repair': ENDLESS_REPAIR,
+      },
+    )
+
+    const defender = getTestParticipant(
+      'defender',
+      {
+        dreadnought: 1,
+      },
+      Faction.muaat,
+      {
+        'Direct Hit': 1,
+      },
+    )
+
+    const attackerHitChance = 0.6
+    const defenderHitChance = 0.6
+    const a2Hit = Math.pow(attackerHitChance, 2)
+    const aMiss = Math.pow(1 - attackerHitChance, 2)
+    const a1Hit = 1 - aMiss - a2Hit
+    const dHit = defenderHitChance
+    const dMiss = 1 - dHit
+
+    const attackerWin =
+      a2Hit * dMiss + a1Hit * dMiss * a1Hit * dMiss + a1Hit * dMiss * a2Hit * dMiss
+    const draw = a2Hit * dHit + a1Hit * dMiss * a1Hit * dHit + a1Hit * dMiss * a2Hit * dHit
+    const defenderWinChance = aMiss * dHit + a1Hit * dMiss * aMiss * dHit + a1Hit * dHit
+
+    const totalChance = attackerWin + draw + defenderWinChance
+
+    const result = getBattleReport(attacker, defender, Place.space, DO_BATTLE_X_TIMES)
+
+    checkResult(result.attacker, (DO_BATTLE_X_TIMES * attackerWin) / totalChance)
+    checkResult(result.draw, (DO_BATTLE_X_TIMES * draw) / totalChance)
+    checkResult(result.defender, (DO_BATTLE_X_TIMES * defenderWinChance) / totalChance)
+  })
+
+  it("Empyrean flagship with endless repairs should lose a 1v20 fighters, since it can't use sustain multiple times in the same combat round", () => {
+    const attacker = getTestParticipant(
+      'attacker',
+      {
+        flagship: 1,
+      },
+      Faction.empyrean,
+      {
+        'Empyrean flagship repair': ENDLESS_REPAIR,
+      },
+    )
+
+    const defender = getTestParticipant(
+      'defender',
+      {
+        fighter: 20,
+      },
+      Faction.sardakk_norr,
+    )
+
+    const result = getBattleReport(attacker, defender, Place.space, DO_BATTLE_X_TIMES)
+
+    checkResult(result.attacker, 0)
+    checkResult(result.draw, 0)
+    checkResult(result.defender, DO_BATTLE_X_TIMES)
+  })
+})

--- a/core/factions/empyrean.test.ts
+++ b/core/factions/empyrean.test.ts
@@ -6,7 +6,7 @@ import { DO_BATTLE_X_TIMES } from '../index.test'
 const ENDLESS_REPAIR = 1000
 
 describe('Empyrean', () => {
-  it('Empyrean flagship with endless repairs should win a 1v1 vs a dread', () => {
+  it('Empyrean flagship with endless repairs should always win vs a dread and PDS', () => {
     const attacker = getTestParticipant(
       'attacker',
       {
@@ -22,11 +22,41 @@ describe('Empyrean', () => {
       'defender',
       {
         dreadnought: 1,
+        pds: 1,
       },
       Faction.muaat,
     )
 
     const result = getBattleReport(attacker, defender, Place.space, DO_BATTLE_X_TIMES)
+
+    checkResult(result.attacker, DO_BATTLE_X_TIMES)
+    checkResult(result.draw, 0)
+    checkResult(result.defender, 0)
+  })
+
+  it('Empyrean flagship with endless repairs and mech should always win vs a mech and PDS', () => {
+    const attacker = getTestParticipant(
+      'attacker',
+      {
+        flagship: 1,
+        mech: 1,
+      },
+      Faction.empyrean,
+      {
+        'Empyrean flagship repair': ENDLESS_REPAIR,
+      },
+    )
+
+    const defender = getTestParticipant(
+      'defender',
+      {
+        pds: 1,
+        mech: 1,
+      },
+      Faction.muaat,
+    )
+
+    const result = getBattleReport(attacker, defender, Place.ground, DO_BATTLE_X_TIMES)
 
     checkResult(result.attacker, DO_BATTLE_X_TIMES)
     checkResult(result.draw, 0)

--- a/core/factions/empyrean.ts
+++ b/core/factions/empyrean.ts
@@ -36,15 +36,6 @@ export const empyrean: BattleEffect[] = [
       _battle: BattleInstance,
       effectName: string,
     ) => {
-      // TODO currently we have no good way of determining if we already used this ability
-      // we need to refactor the assign hit step somehow.
-      // or maybe add some weird id system to ships, I dunno.
-
-      // if (u.takenDamageRound === battle.roundNumber) {
-      // prevent ability from being used several times the same round
-      // return false
-      // }
-
       if (participant.effects[effectName] > 0) {
         u.takenDamage = false
         participant.effects[effectName] -= 1

--- a/core/unit.ts
+++ b/core/unit.ts
@@ -54,6 +54,7 @@ export interface Unit {
 
 export interface UnitInstance extends Unit {
   takenDamage: boolean
+  usedSustain: boolean
   takenDamageRound?: number
   isDestroyed: boolean
 }
@@ -343,6 +344,7 @@ export function createUnit(type: UnitType) {
     ...unit,
     takenDamage: false,
     isDestroyed: false,
+    usedSustain: false,
   }
   return unitInstance
 }

--- a/core/unitGet.test.ts
+++ b/core/unitGet.test.ts
@@ -64,6 +64,37 @@ describe('unitGet', () => {
     expect(unit?.takenDamage).toEqual(false)
   })
 
+  it('getHighestWorthUnit should return an undamaged sustained', () => {
+    const attacker = getTestParticipant('attacker', {
+      dreadnought: 5,
+    })
+
+    const defender = getTestParticipant('defender')
+
+    const participantInstance = getAttackerInstance(attacker, defender)
+
+    participantInstance.units.forEach((u, index) => {
+      if (index === 0) {
+        // No damage
+        u.usedSustain = true
+      }
+      if (index === 1) {
+        // No damage
+        // No sustain
+      }
+      if (index > 1) {
+        u.takenDamage = true
+        u.takenDamageRound = 0
+      }
+    })
+
+    const unit = getHighestWorthUnit(participantInstance, Place.space, true)
+
+    expect(unit?.type).toEqual(UnitType.dreadnought)
+    expect(unit?.takenDamage).toEqual(false)
+    expect(unit?.usedSustain).toEqual(true)
+  })
+
   it('getHighestWorthUnit should respect place', () => {
     const attacker = getTestParticipant('attacker', {
       destroyer: 1,
@@ -111,6 +142,22 @@ describe('unitGet', () => {
     expect(unit).toEqual(undefined)
   })
 
+  it('getHighestWorthSustainUnit should ignore units that just sustained', () => {
+    const attacker = getTestParticipant('attacker', {
+      dreadnought: 1,
+    })
+
+    const defender = getTestParticipant('defender')
+
+    const participantInstance = getAttackerInstance(attacker, defender)
+
+    participantInstance.units[0].usedSustain = true
+
+    const unit = getHighestWorthSustainUnit(participantInstance, Place.space, true)
+
+    expect(unit).toBeUndefined()
+  })
+
   it('getLowestWorthSustainUnit', () => {
     const attacker = getTestParticipant('attacker', {
       flagship: 1,
@@ -124,6 +171,22 @@ describe('unitGet', () => {
     const unit = getLowestWorthSustainUnit(participantInstance, Place.space, true)
 
     expect(unit?.type).toEqual(UnitType.dreadnought)
+  })
+
+  it('getLowestWorthSustainUnit should ignore units that just sustained', () => {
+    const attacker = getTestParticipant('attacker', {
+      dreadnought: 1,
+    })
+
+    const defender = getTestParticipant('defender')
+
+    const participantInstance = getAttackerInstance(attacker, defender)
+
+    participantInstance.units[0].usedSustain = true
+
+    const unit = getLowestWorthSustainUnit(participantInstance, Place.space, true)
+
+    expect(unit).toBeUndefined()
   })
 
   it('getHighestWorthNonSustainUnit', () => {
@@ -165,6 +228,23 @@ describe('unitGet', () => {
     expect(unit?.type).toEqual(UnitType.flagship)
   })
 
+  it('getHighestWorthNonSustainUnit should fetch sustained units', () => {
+    const attacker = getTestParticipant('attacker', {
+      dreadnought: 1,
+    })
+
+    const defender = getTestParticipant('defender')
+
+    const participantInstance = getAttackerInstance(attacker, defender)
+
+    participantInstance.units[0].usedSustain = true
+
+    const unit = getHighestWorthNonSustainUnit(participantInstance, Place.space, true)
+
+    expect(unit?.type).toEqual(UnitType.dreadnought)
+    expect(unit?.usedSustain).toEqual(true)
+  })
+
   it('getLowestWorthUnit', () => {
     const attacker = getTestParticipant('attacker', {
       flagship: 1,
@@ -178,6 +258,36 @@ describe('unitGet', () => {
     const unit = getLowestWorthUnit(participantInstance, Place.space, true)
 
     expect(unit?.type).toEqual(UnitType.dreadnought)
+  })
+
+  it('getLowestWorthUnit should fetch damaged units before sustained', () => {
+    const attacker = getTestParticipant(
+      'attacker',
+      {
+        dreadnought: 2,
+      },
+      Faction.barony_of_letnev,
+      {},
+      {},
+      {
+        dreadnought: 1,
+      },
+    )
+
+    const defender = getTestParticipant('defender')
+
+    const participantInstance = getAttackerInstance(attacker, defender)
+
+    participantInstance.units.forEach((u) => {
+      if (!u.takenDamage) {
+        u.usedSustain = true
+      }
+    })
+
+    const unit = getLowestWorthUnit(participantInstance, Place.space, true)
+
+    expect(unit?.type).toEqual(UnitType.dreadnought)
+    expect(unit?.takenDamage).toEqual(true)
   })
 
   it('getHighestHitUnit', () => {

--- a/core/unitGet.ts
+++ b/core/unitGet.ts
@@ -74,7 +74,10 @@ export function getLowestWorthUnit(p: ParticipantInstance, place: Place, include
     return undefined
   } else {
     return units.reduce((a, b) => {
-      if (a.diePriority === b.diePriority && a.takenDamage !== b.takenDamage) {
+      if (a.diePriority === b.diePriority) {
+        if (a.usedSustain !== b.usedSustain) {
+          return a.usedSustain ? b : a
+        }
         return a.takenDamage ? b : a
       }
       return a.diePriority! > b.diePriority! ? a : b
@@ -100,9 +103,9 @@ export function getUnits(
     }
 
     if (withSustain === true) {
-      return u.sustainDamage && !u.takenDamage
+      return u.sustainDamage && !u.takenDamage && !u.usedSustain
     } else if (withSustain === false) {
-      return !u.sustainDamage || u.takenDamage
+      return !u.sustainDamage || u.takenDamage || u.usedSustain
     } else {
       return true
     }

--- a/core/unitGet.ts
+++ b/core/unitGet.ts
@@ -10,8 +10,11 @@ export function getHighestWorthUnit(p: ParticipantInstance, place: Place, includ
   }
 
   return units.reduce((a, b) => {
-    if (a.diePriority === b.diePriority && a.takenDamage !== b.takenDamage) {
-      return a.takenDamage ? b : a
+    if (a.diePriority === b.diePriority) {
+      if (a.takenDamage !== b.takenDamage) {
+        return a.takenDamage ? b : a
+      }
+      return a.usedSustain ? a : b
     }
     return a.diePriority! > b.diePriority! ? b : a
   })
@@ -75,10 +78,10 @@ export function getLowestWorthUnit(p: ParticipantInstance, place: Place, include
   } else {
     return units.reduce((a, b) => {
       if (a.diePriority === b.diePriority) {
-        if (a.usedSustain !== b.usedSustain) {
-          return a.usedSustain ? b : a
+        if (a.takenDamage !== b.takenDamage) {
+          return a.takenDamage && !b.usedSustain ? b : a
         }
-        return a.takenDamage ? b : a
+        return a.usedSustain ? b : a
       }
       return a.diePriority! > b.diePriority! ? a : b
     })


### PR DESCRIPTION
Add in logic to track sustains in a given assign hits window. Add in tests for Empyrean to verify the logic.