### PR TITLE
Fix cavalry target

### DIFF
--- a/core/factions/nomad.ts
+++ b/core/factions/nomad.ts
@@ -2,7 +2,7 @@ import { BattleInstance, ParticipantInstance } from '../battle-types'
 import { BattleEffect } from '../battleeffect/battleEffects'
 import { Faction, Place } from '../enums'
 import { defaultRoll, UnitInstance, UnitType } from '../unit'
-import { getLowestWorthUnit } from '../unitGet'
+import { getLowestWorthUnit, getWeakestCombatUnit } from '../unitGet'
 
 export const nomad: BattleEffect[] = [
   {
@@ -100,7 +100,7 @@ export const nomad: BattleEffect[] = [
       if (otherParticipant.faction === Faction.nomad) {
         return
       }
-      const worstNonFighterShip = getLowestWorthUnit(participant, Place.space, false)
+      const worstNonFighterShip = getWeakestCombatUnit(participant, Place.space, false)
       if (!worstNonFighterShip) {
         return
       }

--- a/core/unitGet.test.ts
+++ b/core/unitGet.test.ts
@@ -9,6 +9,7 @@ import {
   getHighestWorthUnit,
   getLowestWorthSustainUnit,
   getLowestWorthUnit,
+  getWeakestCombatUnit,
   isHighestHitUnit,
 } from './unitGet'
 
@@ -288,6 +289,22 @@ describe('unitGet', () => {
 
     expect(unit?.type).toEqual(UnitType.dreadnought)
     expect(unit?.takenDamage).toEqual(true)
+  })
+
+  it('getWeakestCombatUnit should return the unit that has the worst hit', () => {
+    const attacker = getTestParticipant('attacker', {
+      carrier: 1,
+      cruiser: 1,
+      mech: 1,
+    })
+
+    const defender = getTestParticipant('defender')
+
+    const participantInstance = getAttackerInstance(attacker, defender)
+
+    const unit = getWeakestCombatUnit(participantInstance, Place.space, true)
+
+    expect(unit?.type).toEqual(UnitType.carrier)
   })
 
   it('getHighestHitUnit', () => {

--- a/core/unitGet.ts
+++ b/core/unitGet.ts
@@ -88,6 +88,26 @@ export function getLowestWorthUnit(p: ParticipantInstance, place: Place, include
   }
 }
 
+export function getWeakestCombatUnit(
+  p: ParticipantInstance,
+  place: Place,
+  includeFighter: boolean,
+) {
+  const units = getUnits(p, place, includeFighter)
+  if (units.length === 0) {
+    return undefined
+  }
+  return units.reduce((a, b) => {
+    if (a.combat?.hit === b.combat?.hit) {
+      if (a.afb?.hit === b.afb?.hit) {
+        return a.sustainDamage > b.sustainDamage ? a : b
+      }
+      return (a.afb?.hit ?? 10) > (b.afb?.hit ?? 10) ? a : b
+    }
+    return (a.combat?.hit ?? 10) > (b.combat?.hit ?? 10) ? a : b
+  })
+}
+
 export function getUnits(
   p: ParticipantInstance,
   place: Place | undefined,


### PR DESCRIPTION
I noticed that the current implementation of the Nomad promissory note automatically picks the lowest *value* unit to target, but this is often suboptimal, since you'd rather target a carrier than a cruiser or destroyer (outside of very unusual circumstances).

This PR adds a function to get the worst unit based on combat stats instead of value, and revises the Nomad promissory note to use that instead.  It's a basic heuristic, but at least it covers the common case of having both cruisers and carriers in the same combat.