### PR TITLE
fix: make upgraded Argent Destroyer destroy infantry

### DIFF
--- a/core/battle-types.ts
+++ b/core/battle-types.ts
@@ -4,7 +4,7 @@
 import { PartialRecord } from '../util/util-types'
 import { BattleEffect } from './battleeffect/battleEffects'
 import { Faction, Place } from './enums'
-import { HitInfo } from './roll'
+import { HitInfo, RollInfo } from './roll'
 import { UnitInstance, UnitType } from './unit'
 
 export type Side = 'attacker' | 'defender'
@@ -136,6 +136,7 @@ export interface ParticipantInstance {
 
   soakHits: number // number of hits that can be cancelled
   hitsToAssign: HitsToAssign
+  afbHitsToAssign: AfbHitsToAssign // to track what happened in anti-fighter barrage separately from combat
 
   // used to track stuff that can only happen a limited number of times per turn
   roundActionTracker: PartialRecord<string, number>
@@ -147,6 +148,11 @@ export interface HitsToAssign {
   hits: number
   hitsToNonFighters: number
   hitsAssignedByEnemy: number
+}
+
+export interface AfbHitsToAssign {
+  fighterHitsToAssign: number
+  rollInfoList: RollInfo[]
 }
 
 export interface BattleResult {

--- a/core/battleSetup.ts
+++ b/core/battleSetup.ts
@@ -160,6 +160,10 @@ function createParticipantInstance(
       hitsToNonFighters: 0,
       hitsAssignedByEnemy: 0,
     },
+    afbHitsToAssign: {
+      fighterHitsToAssign: 0,
+      rollInfoList: [],
+    },
 
     roundActionTracker: {},
     fightActionTracker: {},

--- a/core/factions/argentFlight.test.ts
+++ b/core/factions/argentFlight.test.ts
@@ -30,6 +30,47 @@ describe('Argent flight', () => {
     checkResult(result.defender, DO_BATTLE_X_TIMES * 0.111)
   })
 
+  it('Argent flight upgraded destroyers should destroy infantry', () => {
+    const attacker = getTestParticipant(
+      'attacker',
+      {
+        dreadnought: 5,
+        infantry: 5,
+      },
+      Faction.jol_nar,
+      {},
+      {
+        dreadnought: true,
+      },
+    )
+
+    const defender = getTestParticipant(
+      'defender',
+      {
+        destroyer: 1,
+      },
+      Faction.argent_flight,
+      {},
+      {
+        destroyer: true,
+      },
+    )
+
+    const result = getBattleReport(attacker, defender, Place.space, DO_BATTLE_X_TIMES)
+
+    checkResult(result.attacker, DO_BATTLE_X_TIMES * 1.0)
+    checkResult(result.draw, DO_BATTLE_X_TIMES * 0.0)
+    checkResult(result.defender, DO_BATTLE_X_TIMES * 0.0)
+    let noInfantryDestroyed = 0
+    for (const [survivors, count] of Object.entries(result.attackerSurvivers)) {
+      if (survivors.endsWith('iiiii') && count !== undefined) {
+        noInfantryDestroyed += count
+      }
+    }
+    // 80% chans to not kill infantry. 3 AFB shots. 1 - 0.8^3 = 0.488
+    checkResult(noInfantryDestroyed, DO_BATTLE_X_TIMES * 0.488)
+  })
+
   it('Argent flight flagship prevents pds fire in space', () => {
     const attacker = getTestParticipant(
       'attacker',

--- a/core/factions/argentFlight.ts
+++ b/core/factions/argentFlight.ts
@@ -5,7 +5,7 @@ import { BattleInstance, ParticipantInstance } from '../battle-types'
 import { BattleEffect, registerUse } from '../battleeffect/battleEffects'
 import { Faction, Place } from '../enums'
 import { defaultRoll, UnitInstance, UnitType } from '../unit'
-import { getHighestHitUnit, getLowestWorthSustainUnit } from '../unitGet'
+import { getHighestHitUnit, getLowestWorthSustainUnit, getUnits } from '../unitGet'
 
 export const argentFlight: BattleEffect[] = [
   {
@@ -63,7 +63,8 @@ export const argentFlight: BattleEffect[] = [
       battle: BattleInstance,
       otherParticipant: ParticipantInstance,
     ) => {
-      _times(otherParticipant.hitsToAssign.hits, () => {
+      // raid formation
+      _times(otherParticipant.afbHitsToAssign.fighterHitsToAssign, () => {
         const bestSustainUnit = getLowestWorthSustainUnit(otherParticipant, battle.place, true)
         if (bestSustainUnit) {
           logWrapper(
@@ -105,7 +106,8 @@ export const argentFlight: BattleEffect[] = [
       battle: BattleInstance,
       otherParticipant: ParticipantInstance,
     ) => {
-      _times(otherParticipant.hitsToAssign.hits, () => {
+      // raid formation
+      _times(otherParticipant.afbHitsToAssign.fighterHitsToAssign, () => {
         const bestSustainUnit = getLowestWorthSustainUnit(otherParticipant, battle.place, true)
         if (bestSustainUnit) {
           logWrapper(
@@ -117,6 +119,21 @@ export const argentFlight: BattleEffect[] = [
           bestSustainUnit.takenDamageRound = 0
         }
       })
+      // strike wing alpha II
+      for (const rollInfo of otherParticipant.afbHitsToAssign.rollInfoList) {
+        if (rollInfo.roll >= 9) {
+          const infantryToDestroy = getUnits(otherParticipant, undefined, false) // place must be undefined or infantry are filtered out
+            .find((u) => u.type === UnitType.infantry && !u.isDestroyed)
+          if (infantryToDestroy) {
+            logWrapper(
+              `${
+                p.side === 'attacker' ? 'defender' : 'attacker'
+              } destroyed infantry from Strike Wing Alpha II`,
+            )
+            infantryToDestroy.isDestroyed = true
+          }
+        }
+      }
     },
   },
   {


### PR DESCRIPTION
- Add a separate piece of state just for tracking hits from anti-fighter barrage
- Use this new piece of state to implement the infantry-destroying ability of upgraded Argent destroyers