### PR TITLE
Fix Neutral infantry combat

### DIFF
--- a/core/factions/neutral.test.ts
+++ b/core/factions/neutral.test.ts
@@ -1,26 +1,50 @@
+import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 
-import { TEST_NUMBER_OF_ROLLS } from '@/core/constant'
-import { getTestParticipant, testBattleReport } from '@/util/util.test'
+import { setupBattle } from '@/core/battleSetup'
+import { UnitType } from '@/core/unit'
+import { getTestParticipant } from '@/util/util.test'
 
 describe('Neutral', () => {
-  it('Neutral infantry should be stronger than default infantry', () => {
+  it('Neutral infantry should use baseline combat (8)', () => {
     const attacker = getTestParticipant(
       'attacker',
       {
-        infantry: 2,
+        infantry: 1,
       },
       'Neutral',
     )
 
-    const defender = getTestParticipant('defender', {
-      infantry: 2,
-    })
+    const defender = getTestParticipant('defender')
 
-    testBattleReport(attacker, defender, 'ground', TEST_NUMBER_OF_ROLLS, [
-      { side: 'attacker', percentage: 0.677 },
-      { side: 'draw', percentage: 0.096 },
-      { side: 'defender', percentage: 0.227 },
-    ])
+    const battleInstance = setupBattle({ place: 'ground', attacker, defender })
+    const infantry = battleInstance.attacker.units.find((u) => u.type === UnitType.infantry)
+    if (!infantry?.combat) {
+      throw new Error('Expected attacker infantry to exist and have combat data')
+    }
+    assert.equal(infantry.combat.hit, 8)
+  })
+
+  it('Neutral infantry should ignore infantry upgrade toggle', () => {
+    const attacker = getTestParticipant(
+      'attacker',
+      {
+        infantry: 1,
+      },
+      'Neutral',
+      {},
+      {
+        infantry: true,
+      },
+    )
+
+    const defender = getTestParticipant('defender')
+
+    const battleInstance = setupBattle({ place: 'ground', attacker, defender })
+    const infantry = battleInstance.attacker.units.find((u) => u.type === UnitType.infantry)
+    if (!infantry?.combat) {
+      throw new Error('Expected attacker infantry to exist and have combat data')
+    }
+    assert.equal(infantry.combat.hit, 8)
   })
 })

--- a/core/factions/neutral.ts
+++ b/core/factions/neutral.ts
@@ -5,7 +5,7 @@ import { defaultRoll, UnitInstance, UnitType } from '../unit'
 /**
  * Neutral faction is actually tricky. Default strength is higher for the following units:
  *
- * cruiser, destroyers, fighters, infantry
+ * cruiser, destroyers, fighters
  *
  * And on the other units, we need to prevent upgrade from making them stronger.
  *
@@ -48,6 +48,17 @@ export const neutral: BattleEffect[] = [
   },
 
   // no changes needed to carrier
+
+  {
+    name: 'Neutral infantry upgrade',
+    type: 'faction-tech',
+    faction: 'Neutral',
+    place: 'both',
+    unit: UnitType.infantry,
+    transformUnit: (unit: UnitInstance) => {
+      return unit
+    },
+  },
 
   {
     type: 'faction',
@@ -123,7 +134,7 @@ export const neutral: BattleEffect[] = [
           ...unit,
           combat: {
             ...defaultRoll,
-            hit: 6,
+            hit: 8,
           },
         }
       } else {


### PR DESCRIPTION
- Neutral infantry uses baseline combat 8
- Block infantry upgrade from improving Neutral infantry